### PR TITLE
Changed point type to publish estimated normals.

### DIFF
--- a/depth_segmentation/include/depth_segmentation/common.h
+++ b/depth_segmentation/include/depth_segmentation/common.h
@@ -2,6 +2,7 @@
 #define DEPTH_SEGMENTATION_COMMON_H_
 
 #include <string>
+#include <vector>
 
 #include <glog/logging.h>
 #include <opencv2/highgui.hpp>
@@ -9,6 +10,13 @@
 #include <opencv2/viz/vizcore.hpp>
 
 namespace depth_segmentation {
+struct Segment {
+  std::vector<cv::Vec3f> points;
+  std::vector<cv::Vec3f> normals;
+  std::vector<cv::Vec3f> original_colors;
+  std::set<size_t> label;
+  std::set<size_t> semantic_label;
+};
 
 const static std::string kDebugWindowName = "DebugImages";
 

--- a/depth_segmentation/include/depth_segmentation/depth_segmentation.h
+++ b/depth_segmentation/include/depth_segmentation/depth_segmentation.h
@@ -150,7 +150,7 @@ class DepthSegmenter {
   void labelMap(const cv::Mat& rgb_image, const cv::Mat& depth_image,
                 const cv::Mat& depth_map, const cv::Mat& edge_map,
                 const cv::Mat& normal_map, cv::Mat* labeled_map,
-                std::vector<std::vector<std::vector<cv::Vec3f>>>* segments);
+                std::vector<Segment>* segments);
   void inpaintImage(const cv::Mat& depth_image, const cv::Mat& edge_map,
                     const cv::Mat& label_map, cv::Mat* inpainted);
   void findBlobs(const cv::Mat& binary,

--- a/depth_segmentation/include/depth_segmentation/ros_common.h
+++ b/depth_segmentation/include/depth_segmentation/ros_common.h
@@ -8,7 +8,7 @@
 namespace depth_segmentation {
 const static std::string kRgbImageTopic = "/camera/rgb/image_raw";
 const static std::string kRgbCameraInfoTopic = "/camera/rgb/camera_info";
-const static std::string kDepthImageTopic = "/camera/depth/image_raw";
+const static std::string kDepthImageTopic = "/camera/depth_registered/image_raw";
 const static std::string kDepthCameraInfoTopic = "/camera/depth/camera_info";
 
 const static std::string kTfWorldFrame = "world";


### PR DESCRIPTION
Point type was changed to pcl::PointSurfel in order to publish also the estimated normals within the /depth_segmentation/object_segment topic. Surfels were chosen so that we could also publish confidence, curvature and radius, but this feature is not added yet. 

Also, we assign the original color to the points. Giving random color is only usefull for showing the whole segmented scene, but not for the topic which publishes the individual segements.