### PR TITLE
Fix to make segments and masks of same size, one more bug fix

### DIFF
--- a/depth_segmentation/src/depth_segmentation.cpp
+++ b/depth_segmentation/src/depth_segmentation.cpp
@@ -992,7 +992,7 @@ void segmentSingleFrame(const cv::Mat& rgb_image, const cv::Mat& depth_image,
 
   // Compute depth map from rescaled depth image.
   cv::Mat depth_map(rescaled_depth.size(), CV_32FC3);
-  depth_segmenter.computeDepthMap(depth_image, &depth_map);
+  depth_segmenter.computeDepthMap(rescaled_depth, &depth_map);
 
   // Compute normals based on specified method.
   cv::Mat normal_map(depth_map.size(), CV_32FC3, 0.0f);


### PR DESCRIPTION
- masks and segments have the same size (fixed with @ffurrer )
- wrong depth was passed to depth segmenter which caused  crashes when original depth image was of 16UC1 type