### PR TITLE
added normal map as output param

### DIFF
--- a/depth_segmentation/include/depth_segmentation/depth_segmentation.h
+++ b/depth_segmentation/include/depth_segmentation/depth_segmentation.h
@@ -177,6 +177,7 @@ class DepthSegmenter {
 void segmentSingleFrame(const cv::Mat& rgb_image, const cv::Mat& depth_image,
                         const cv::Mat& depth_intrinsics,
                         depth_segmentation::Params& params, cv::Mat* label_map,
+                        cv::Mat* normal_map,
                         std::vector<cv::Mat>* segment_masks,
                         std::vector<Segment>* segments);
 


### PR DESCRIPTION
Use case happens when working with downscaled depth images to achieve faster depth segmentation.
The normals that we can currently get from segment.normals only cover the given downscaled image and are therefore sparser and presented in a vector of normals. We need a full normals map **image** to later be able to simply resize it and avoid computing normals again.