### PR TITLE
Mask RCNN ROS on by default

### DIFF
--- a/depth_segmentation/CMakeLists.txt
+++ b/depth_segmentation/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
   endif()
 endif()
 
-set(WITH_MASKRCNNROS OFF)
+set(WITH_MASKRCNNROS ON)
 
 if (WITH_MASKRCNNROS)
   find_package(mask_rcnn_ros QUIET)

--- a/depth_segmentation/launch/semantic_instance_segmentation.launch
+++ b/depth_segmentation/launch/semantic_instance_segmentation.launch
@@ -1,9 +1,10 @@
 <launch>
   <arg name="rgb_topic" default="/camera/rgb/image_raw" />
+  <arg name="visualize" default="true" />
 
   <node name="mask_rcnn" pkg="mask_rcnn_ros" type="mask_rcnn_node.py" output="screen">
       <remap from="~input" to="$(arg rgb_topic)" />
-      <param name="~visualization" value="true" />
+      <param name="~visualization" value="$(arg visualize)" />
   </node>
 
   <arg name="depth_segmentation_node_params_name" default="$(find depth_segmentation)/cfg/scenenn_config.yaml"/>
@@ -12,5 +13,6 @@
     <rosparam command="load" file="$(arg depth_segmentation_node_params_name)" />
     <param name="rgb_image_sub_topic" value="$(arg rgb_topic)" />
     <param name="semantic_instance_segmentation/enable" value="true"/>
+    <param name="label_display" value="$(arg visualize)"/>
   </node>
 </launch>


### PR DESCRIPTION
Set Mask RCNN ROS compilation flag to ON by default since:
- it anyways fails quietly should mask rcnn ros not be found
- it does not necessarily use it (that is controlled by a param)